### PR TITLE
ci: add build workflow for Renovate PR validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dbt
+        run: pip install dbt-core dbt-duckdb
+
+      - name: Validate project YAML
+        run: python -c "import yaml; yaml.safe_load(open('dbt_project.yml'))"
+
+      - name: Check dbt project
+        run: |
+          mkdir -p ~/.dbt
+          cat > ~/.dbt/profiles.yml << 'PROFILES'
+          dbt_tools:
+            target: ci
+            outputs:
+              ci:
+                type: duckdb
+                path: ":memory:"
+          PROFILES
+          dbt parse

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,13 +15,13 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install dbt
-        run: pip install dbt-core dbt-duckdb
+      - name: Install dependencies
+        run: pip install dbt-core dbt-duckdb yamllint
 
-      - name: Validate project YAML
-        run: python -c "import yaml; yaml.safe_load(open('dbt_project.yml'))"
+      - name: Lint YAML files
+        run: yamllint -d relaxed dbt_project.yml
 
-      - name: Check dbt project
+      - name: Validate dbt project
         run: |
           mkdir -p ~/.dbt
           cat > ~/.dbt/profiles.yml << 'PROFILES'
@@ -32,4 +32,4 @@ jobs:
                 type: duckdb
                 path: ":memory:"
           PROFILES
-          dbt parse
+          dbt parse --profile dbt_tools --no-partial-parse


### PR DESCRIPTION
## Summary
- Add a CI workflow that triggers on PRs and pushes to main
- Validates the dbt project by running `dbt parse` with a minimal DuckDB profile
- Ensures Renovate dependency upgrade PRs get a build status (pass/fail)